### PR TITLE
Remove react-bootstrap package and add the updated version

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "firebase": "^8.8.1",
     "formik": "^2.2.9",
     "react": "^17.0.2",
-    "react-bootstrap": "^1.6.1",
+    "react-bootstrap": "2.0.0-beta.0",
     "react-dom": "^17.0.2",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2300,9 +2300,9 @@
     "@types/react" "*"
 
 "@types/react@*", "@types/react@>=16.14.8", "@types/react@>=16.9.11":
-  version "17.0.15"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.15.tgz#c7533dc38025677e312606502df7656a6ea626d0"
-  integrity sha512-uTKHDK9STXFHLaKv6IMnwp52fm0hwU+N89w/p9grdUqcFA6WuqDyPhaWopbNyE1k/VhgzmHl8pu1L4wITtmlLw==
+  version "17.0.16"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.16.tgz#056f40c45645761527baeb7d89d842a6abdf285a"
+  integrity sha512-3kCUiOOlQTwUUvjNFkbBTWMTxdTGybz/PfjCw9JmaRGcEDBQh+nGMg7/E9P2rklhJuYVd25IYLNcvqgSPCPksg==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -10011,10 +10011,10 @@ react-app-polyfill@^2.0.0:
     regenerator-runtime "^0.13.7"
     whatwg-fetch "^3.4.1"
 
-react-bootstrap@^1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/react-bootstrap/-/react-bootstrap-1.6.1.tgz#c5493c028ede885826b72eb31e66f6f0a52ab007"
-  integrity sha512-ojEPQ6OtyIMdLg0Smofk+85PKN6MLKQX3bU0Vwmok/4yNa8DQ2vCGhO2IgHJvT+ERQZ4X+gAQcdn6msAHSwLBg==
+react-bootstrap@2.0.0-beta.0:
+  version "2.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/react-bootstrap/-/react-bootstrap-2.0.0-beta.0.tgz#555bc901e5cca7aa4bf27b6a493af3d0c1cc386f"
+  integrity sha512-9grXyFdznG7r7HT7etkiKHkgqVVgasDFjkTtNCAx9xAQllAjKl6vuBGBVc3F+KLNpdTzrxrx5RWNIgd8ZpascA==
   dependencies:
     "@babel/runtime" "^7.14.0"
     "@restart/context" "^2.1.4"


### PR DESCRIPTION
Here's what happens when you add the Accordion component with tha outdated version of react-bootstrap:
https://user-images.githubusercontent.com/80679047/128626088-adf488b9-bc17-435d-9861-fa964cc37f9e.mov

Here's after I updated it:
https://user-images.githubusercontent.com/80679047/128626241-d9668ab4-57f8-4466-9eeb-a0dcafd13efd.mov

After this pr got merged, you updated the develop and merged the develop into your working branch and if you got an error when you tried to use accordion component then you need to remove the folder named .cache inside the node_modules folder, run the `yarn cache clean --all` command and `yarn install` and `yarn start` again. 

Closes #22 
